### PR TITLE
Add support for number prop type

### DIFF
--- a/src/prop-types/number-type.ts
+++ b/src/prop-types/number-type.ts
@@ -1,0 +1,47 @@
+import { Type } from './type';
+
+export class NumberType extends Type {
+  isSupported(): boolean {
+    return true;
+  }
+
+  annotation(): string {
+    // Assuming for now that all number props take only integers. If we need to
+    // support floating point values for a prop in the future, consider changing
+    // this to Float, or using some prop naming convention to distinguish
+    // between Int and Float props (TypeScript does not draw a distinction).
+    return 'Int';
+  }
+
+  customTypeNames(): string[] {
+    return [];
+  }
+
+  customTypeDeclarations(): string[] {
+    return [];
+  }
+
+  attributeEncoderName(): string {
+    return 'String.fromInt';
+  }
+
+  jsonEncoderName(): string {
+    return 'Encode.int';
+  }
+
+  encoders(): string[] {
+    return [];
+  }
+
+  typeAliasNames(): string[] {
+    return [];
+  }
+
+  typeAliasDeclarations(): string[] {
+    return [];
+  }
+
+  isSettableAsElementAttribute(): boolean {
+    return true;
+  }
+}

--- a/src/prop-types/prop-type-from-metadata.ts
+++ b/src/prop-types/prop-type-from-metadata.ts
@@ -2,6 +2,7 @@ import { AnyObjectType } from './any-object-type';
 import { BooleanType } from './boolean-type';
 import { EnumeratedStringType } from './enumerated-string-type';
 import { FixedObjectType } from './fixed-object-type';
+import { NumberType } from './number-type';
 import { StringType } from './string-type';
 import { ConcreteTypeClass, Type } from './type';
 import { TypeMetadata } from './types';
@@ -35,6 +36,7 @@ const propTypeClassByType: {
   thenTypeClass: ConcreteTypeClass;
 }[] = [
   { ifTypeMatches: /^boolean$/, thenTypeClass: BooleanType },
+  { ifTypeMatches: /^number$/, thenTypeClass: NumberType },
   { ifTypeMatches: /^string$/, thenTypeClass: StringType },
   { ifTypeMatches: /^object$/, thenTypeClass: AnyObjectType },
   {


### PR DESCRIPTION
For a Stencil component prop like this:

```typescript
@Prop() foo: number = 0;
```

generate an Elm prop field:

```elm
  foo : Maybe Int
```

that writes an HTML string attribute like this:

```elm
  attributes.foo |> Maybe.map (String.fromInt >> attribute "foo")
```

It's interesting to note that Stencil will take a string HTML attribute (`foo="10"`) and correctly convert it to a JavaScript `number` inside the component if the prop is typed as a `number`. Therefore we do not need to set this as a JavaScript `property` in Elm (although we could).