### PR TITLE
Add support for component props with union types

### DIFF
--- a/src/object-type-parser.ts
+++ b/src/object-type-parser.ts
@@ -15,6 +15,7 @@ type ParserState =
   | 'afterObjectType'
   | 'beforePrimitiveType'
   | 'afterField'
+  | 'end'
   | 'done';
 
 export function objectTypeParser(resolvedType: string) {
@@ -83,7 +84,15 @@ export function objectTypeParser(resolvedType: string) {
             break;
 
           case 'afterField':
-            this.branch('}', 'done', 'beforeFieldName');
+            this.branch('}', 'end', 'beforeFieldName');
+            break;
+
+          case 'end':
+            this.expect(
+              { regExp: /^}$/ },
+              'the end of the type string',
+              'done',
+            );
             break;
         }
       }
@@ -104,7 +113,7 @@ export function objectTypeParser(resolvedType: string) {
         const matches = resolvedType
           .substring(parsePosition)
           .match(expected.regExp);
-        if (matches && matches[1]) {
+        if (matches && !(expected.capture && !matches[1])) {
           if (expected.capture) {
             expected.capture(matches[1]);
           }

--- a/src/output-elm.ts
+++ b/src/output-elm.ts
@@ -165,8 +165,8 @@ function componentElm(
     [
       ...new Set( // remove duplicates
         attributeConfigs.flatMap((attributeConfig) => [
-          ...attributeConfig.typeAliasDeclarations(),
           ...attributeConfig.customTypeDeclarations(),
+          ...attributeConfig.typeAliasDeclarations(),
           ...attributeConfig.encoders(),
         ]),
       ),

--- a/src/prop-types/enumerated-string-type.ts
+++ b/src/prop-types/enumerated-string-type.ts
@@ -16,6 +16,7 @@ export class EnumeratedStringType extends Type {
         break;
 
       case 'object-field':
+      case 'union-member':
         this.name = metadata.name;
         this.typeString = metadata.type;
         break;
@@ -47,7 +48,7 @@ export class EnumeratedStringType extends Type {
     ];
   }
 
-  private customTypeConstructors() {
+  private customTypeConstructors(): string[] {
     return this.stringValues().map(this.constructorForStringValue, this);
   }
 

--- a/src/prop-types/fixed-object-type.ts
+++ b/src/prop-types/fixed-object-type.ts
@@ -1,4 +1,4 @@
-import { objectTypeParser } from '../object-type-parser';
+import { objectTypeParser } from './object-type-parser';
 import { Type } from './type';
 import { capitalize } from '../utils';
 import { TypeFactory, TypeMetadata } from './types';
@@ -19,6 +19,7 @@ export class FixedObjectType extends Type {
         break;
 
       case 'object-field':
+      case 'union-member':
         this.name = metadata.name;
         this.typeString = metadata.type;
         break;
@@ -29,7 +30,7 @@ export class FixedObjectType extends Type {
     try {
       this.fields = objectTypeParser(resolvedType)
         .fields()
-        .map(({ name, type }) => ({
+        .map(({ name, type }: { name: string; type: string }) => ({
           name,
           type: typeFactory({ kind: 'object-field', name, type }),
         }));

--- a/src/prop-types/object-type-parser.ts
+++ b/src/prop-types/object-type-parser.ts
@@ -1,0 +1,185 @@
+/**
+ * A really dumb parser that finds fields of a TypeScript object type and
+ * reports their types as strings.
+ *
+ * E.g. "{ foo: string; bar: { baz: object; }; }"
+ *
+ * Please make Kev write a test suite for this so that it is maintainable.
+ */
+type ParserState =
+  | 'start'
+  | 'beforeFieldName'
+  | 'beforeFieldType'
+  | 'beforeObjectType'
+  | 'beforePrimitiveType'
+  | 'afterField'
+  | 'end'
+  | 'done';
+
+export function objectTypeParser(resolvedType: string) {
+  let parsePosition = 0;
+  let parserState: ParserState = 'start';
+  let fields: { name: string; type: string }[] = [];
+  let nextFieldName: string;
+  let delimitedValue = '';
+  let delimiterNestingLevel = 0;
+
+  return {
+    parse() {
+      while (parserState !== 'done') {
+        switch (parserState) {
+          case 'start':
+            this.expect(
+              '{ ',
+              'an opening brace for the start of the object type',
+              'beforeFieldName',
+            );
+            break;
+
+          case 'beforeFieldName':
+            this.expect(
+              {
+                regExp: /^(\w+): /,
+                capture: (fieldName) => {
+                  nextFieldName = fieldName;
+                },
+              },
+              'a field name in the object type',
+              'beforeFieldType',
+            );
+            break;
+
+          case 'beforeFieldType':
+            this.branch('{ ', 'beforeObjectType', 'beforePrimitiveType');
+            break;
+
+          case 'beforeObjectType':
+            this.delimitedString(
+              '{',
+              '}; ',
+              (objectTypeWithSemicolonSpace) => {
+                fields.push({
+                  name: nextFieldName,
+                  type: objectTypeWithSemicolonSpace.slice(0, -'; '.length),
+                });
+              },
+              `a nested object type for the ${nextFieldName} field`,
+              'afterField',
+            );
+            break;
+
+          case 'beforePrimitiveType':
+            this.expect(
+              {
+                regExp: /^([^;]+); /,
+                capture: (fieldType) => {
+                  fields.push({ name: nextFieldName, type: fieldType });
+                },
+              },
+              `a primitive type for the ${nextFieldName} field`,
+              'afterField',
+            );
+            break;
+
+          case 'afterField':
+            this.branch('}', 'end', 'beforeFieldName');
+            break;
+
+          case 'end':
+            this.expect(
+              { regExp: /^}$/ },
+              'the end of the type string',
+              'done',
+            );
+            break;
+        }
+      }
+      return this;
+    },
+    expect(
+      expected: string | { regExp: RegExp; capture?: (value: string) => void },
+      expectedMsg: string,
+      nextState: ParserState,
+    ) {
+      if (typeof expected === 'string') {
+        if (resolvedType.substring(parsePosition).startsWith(expected)) {
+          parsePosition += expected.length;
+        } else {
+          throw new Error(`Expected ${expectedMsg}`);
+        }
+      } else {
+        const matches = resolvedType
+          .substring(parsePosition)
+          .match(expected.regExp);
+        if (matches && !(expected.capture && !matches[1])) {
+          if (expected.capture) {
+            expected.capture(matches[1]);
+          }
+          parsePosition += matches[0].length;
+        } else {
+          throw new Error(
+            `Expected ${expectedMsg}. Found instead: ${resolvedType.substring(
+              parsePosition,
+            )}`,
+          );
+        }
+      }
+      parserState = nextState;
+    },
+    branch(
+      match: string | RegExp,
+      nextStateIf: ParserState,
+      nextStateElse: ParserState,
+    ) {
+      parserState = (
+        typeof match === 'string'
+          ? resolvedType.substring(parsePosition).startsWith(match)
+          : resolvedType.substring(parsePosition).match(match)
+      )
+        ? nextStateIf
+        : nextStateElse;
+    },
+    delimitedString(
+      startDelimiter: string,
+      endDelimiter: string,
+      capture: (value: string) => void,
+      expectedMsg: string,
+      nextState: ParserState,
+    ) {
+      const nextStart = resolvedType.indexOf(startDelimiter, parsePosition);
+      const nextEnd = resolvedType.indexOf(endDelimiter, parsePosition);
+
+      if (delimiterNestingLevel === 0) {
+        delimitedValue = '';
+      }
+
+      // if a start delimiter is next, increase nesting level
+      if (nextStart >= 0 && nextStart < nextEnd) {
+        const nextParsePosition = nextStart + startDelimiter.length;
+        delimitedValue += resolvedType.slice(parsePosition, nextParsePosition);
+        delimiterNestingLevel++;
+        parsePosition = nextParsePosition;
+      }
+      // if an end delimiter is next, decrease nesting level
+      else if (nextStart < 0 || nextEnd < nextStart) {
+        const nextParsePosition = nextEnd + endDelimiter.length;
+        delimitedValue += resolvedType.slice(parsePosition, nextParsePosition);
+        delimiterNestingLevel--;
+        parsePosition = nextParsePosition;
+
+        if (delimiterNestingLevel === 0) {
+          capture(delimitedValue);
+          parserState = nextState;
+          return;
+        }
+      }
+
+      if (nextEnd < 0 || delimiterNestingLevel <= 0) {
+        throw new Error(`Expected ${expectedMsg}`);
+      }
+    },
+    fields() {
+      return fields;
+    },
+  }.parse();
+}

--- a/src/prop-types/prop-type-from-metadata.ts
+++ b/src/prop-types/prop-type-from-metadata.ts
@@ -6,6 +6,7 @@ import { NumberType } from './number-type';
 import { StringType } from './string-type';
 import { ConcreteTypeClass, Type } from './type';
 import { TypeFactory, TypeMetadata } from './types';
+import { UnionType } from './union-type';
 import { UnsupportedType } from './unsupported-type';
 
 export function propTypeFromMetadata(metadata: TypeMetadata): Type {
@@ -55,5 +56,9 @@ const propTypeClassByType: {
   {
     ifTypeMatches: /^(undefined \| )?{ (\w+: .+; )+}$/, // { key1: type1; key2: type2; }
     thenTypeClass: FixedObjectType,
+  },
+  {
+    ifTypeMatches: /^(undefined \| )?(.+ \| )+[^\|]+$/, // supportedType1 | supportedType2
+    thenTypeClass: UnionType,
   },
 ];

--- a/src/prop-types/types.ts
+++ b/src/prop-types/types.ts
@@ -2,7 +2,10 @@ import { ComponentCompilerProperty } from '@stencil/core/internal';
 
 export type TypeFactory<type> = (metadata: TypeMetadata) => type;
 
-export type TypeMetadata = ComponentPropertyMetadata | ObjectFieldMetadata;
+export type TypeMetadata =
+  | ComponentPropertyMetadata
+  | ObjectFieldMetadata
+  | UnionMemberMetadata;
 
 export type ComponentPropertyMetadata = {
   kind: 'component-property';
@@ -11,6 +14,12 @@ export type ComponentPropertyMetadata = {
 
 export type ObjectFieldMetadata = {
   kind: 'object-field';
+  name: string;
+  type: string;
+};
+
+export type UnionMemberMetadata = {
+  kind: 'union-member';
   name: string;
   type: string;
 };

--- a/src/prop-types/union-type-parser.ts
+++ b/src/prop-types/union-type-parser.ts
@@ -1,28 +1,24 @@
 /**
- * A really dumb parser that finds fields of a TypeScript object type and
+ * A really dumb parser that finds members of a TypeScript union type and
  * reports their types as strings.
  *
- * E.g. "{ foo: string; bar: { baz: object; }; }"
+ * E.g. "boolean | string[] | { foo: string; }" => ["boolean", "string[]", "{ foo: string; }"]
  *
  * Please make Kev write a test suite for this so that it is maintainable.
  */
 type ParserState =
   | 'start'
-  | 'beforeFieldName'
-  | 'beforeFieldType'
-  | 'beforeObjectType'
-  | 'inNestedDelimiter'
-  | 'afterObjectType'
-  | 'beforePrimitiveType'
-  | 'afterField'
-  | 'end'
+  | 'beforeMember'
+  | 'beforeObjectMember'
+  | 'beforePrimitiveMember'
+  | 'afterMember'
+  | 'beforeDelimiter'
   | 'done';
 
-export function objectTypeParser(resolvedType: string) {
+export function unionTypeParser(resolvedType: string) {
   let parsePosition = 0;
   let parserState: ParserState = 'start';
-  let fields: { name: string; type: string }[] = [];
-  let nextFieldName: string;
+  let members: { type: string }[] = [];
   let delimitedValue = '';
   let delimiterNestingLevel = 0;
 
@@ -31,67 +27,46 @@ export function objectTypeParser(resolvedType: string) {
       while (parserState !== 'done') {
         switch (parserState) {
           case 'start':
-            this.expect(
-              '{ ',
-              'an opening brace for the start of the object type',
-              'beforeFieldName',
-            );
+          case 'beforeMember':
+            this.branch('{ ', 'beforeObjectMember', 'beforePrimitiveMember');
             break;
 
-          case 'beforeFieldName':
-            this.expect(
-              {
-                regExp: /^(\w+): /,
-                capture: (fieldName) => {
-                  nextFieldName = fieldName;
-                },
-              },
-              'a field name in the object type',
-              'beforeFieldType',
-            );
-            break;
-
-          case 'beforeFieldType':
-            this.branch('{ ', 'beforeObjectType', 'beforePrimitiveType');
-            break;
-
-          case 'beforeObjectType':
+          case 'beforeObjectMember':
             this.delimitedString(
               '{',
-              '}; ',
-              (objectTypeWithSemicolonSpace) => {
-                fields.push({
-                  name: nextFieldName,
-                  type: objectTypeWithSemicolonSpace.slice(0, -'; '.length),
+              '}',
+              (objectType) => {
+                members.push({
+                  type: objectType.slice(0),
                 });
               },
-              `a nested object type for the ${nextFieldName} field`,
-              'afterField',
+              `a union member object type`,
+              'afterMember',
             );
             break;
 
-          case 'beforePrimitiveType':
+          case 'beforePrimitiveMember':
             this.expect(
               {
-                regExp: /^([^;]+); /,
-                capture: (fieldType) => {
-                  fields.push({ name: nextFieldName, type: fieldType });
+                regExp: /^([^|]+)(?= \| |$)/,
+                capture: (type) => {
+                  members.push({ type });
                 },
               },
-              `a primitive type for the ${nextFieldName} field`,
-              'afterField',
+              'a primitive member type',
+              'afterMember',
             );
             break;
 
-          case 'afterField':
-            this.branch('}', 'end', 'beforeFieldName');
+          case 'afterMember':
+            this.branch(/^$/, 'done', 'beforeDelimiter');
             break;
 
-          case 'end':
+          case 'beforeDelimiter':
             this.expect(
-              { regExp: /^}$/ },
-              'the end of the type string',
-              'done',
+              ' | ',
+              'a "|" delimiter between union members',
+              'beforeMember',
             );
             break;
         }
@@ -180,8 +155,8 @@ export function objectTypeParser(resolvedType: string) {
         throw new Error(`Expected ${expectedMsg}`);
       }
     },
-    fields() {
-      return fields;
+    members() {
+      return members;
     },
   }.parse();
 }

--- a/src/prop-types/union-type.ts
+++ b/src/prop-types/union-type.ts
@@ -1,0 +1,141 @@
+import { unionTypeParser } from './union-type-parser';
+import { capitalize } from '../utils';
+import { Type } from './type';
+import { TypeFactory, TypeMetadata } from './types';
+
+type Member = { name: string; type: Type };
+
+export class UnionType extends Type {
+  name: string;
+  typeString: string;
+  members: Member[];
+  memberParserError?: Error;
+
+  constructor(metadata: TypeMetadata, typeFactory: TypeFactory<Type>) {
+    super(metadata, typeFactory);
+
+    switch (metadata.kind) {
+      case 'component-property':
+        this.name = metadata.propMeta.name;
+        this.typeString = metadata.propMeta.complexType.resolved;
+        break;
+
+      case 'object-field':
+      case 'union-member':
+        this.name = metadata.name;
+        this.typeString = metadata.type;
+        break;
+    }
+
+    // strip "undefined | " from the start of the type of an optional prop
+    const resolvedType = this.typeString.replace(/^undefined \| /, '');
+    try {
+      this.members = unionTypeParser(resolvedType)
+        .members()
+        .map(({ type }: { type: string }, index: number) => ({
+          name: this.memberConstructorName(index),
+          type: typeFactory({
+            kind: 'union-member',
+            name: this.memberValueTypeAliasName(index),
+            type,
+          }),
+        }));
+    } catch (parserError) {
+      this.members = [];
+      this.memberParserError = parserError;
+    }
+  }
+
+  private memberConstructorName(memberIndex: number): string {
+    // Could parse and use names from complexType.original to generate
+    // nicer constructor function names and type aliases
+    return `${this.name}${memberIndex}`;
+  }
+
+  private memberValueTypeAliasName(memberIndex: number): string {
+    return `${this.name}${memberIndex}Value`;
+  }
+
+  isSupported(): boolean {
+    return (
+      !this.memberParserError &&
+      this.members.every(({ type }) => type.isSupported())
+    );
+  }
+
+  annotation(): string {
+    return this.customTypeName();
+  }
+
+  customTypeNames(): string[] {
+    return [
+      this.customTypeName(),
+      ...this.members.flatMap(({ type }) => type.customTypeNames()),
+    ];
+  }
+
+  private customTypeName(): string {
+    return capitalize(this.name);
+  }
+
+  customTypeDeclarations(): string[] {
+    return [
+      this.customTypeDeclaration(),
+      ...this.members.flatMap(({ type }) => type.customTypeDeclarations()),
+    ];
+  }
+
+  private customTypeDeclaration(): string {
+    return [
+      `type ${this.customTypeName()}`,
+      `    = ${this.customTypeConstructors().join('\n    | ')}`,
+    ].join('\n');
+  }
+
+  private customTypeConstructors(): string[] {
+    return this.members.map(
+      ({ name, type }) => `${capitalize(name)} ${type.annotation()}`,
+    );
+  }
+
+  attributeEncoderName(): string {
+    return `${this.name}Encoder`;
+  }
+
+  jsonEncoderName(): string {
+    return this.attributeEncoderName();
+  }
+
+  encoders(): string[] {
+    return [
+      [
+        [
+          `${this.name}Encoder : ${this.customTypeName()} -> Value`,
+          `${this.name}Encoder ${this.name} =`,
+          `    case ${this.name} of`,
+        ],
+        this.members.map(({ name, type }) =>
+          [
+            `        ${capitalize(name)} value ->`,
+            `            ${type.jsonEncoderName()} value`,
+          ].join('\n'),
+        ),
+      ]
+        .flat()
+        .join('\n'),
+      ...this.members.flatMap(({ type }) => type.encoders()),
+    ];
+  }
+
+  typeAliasNames(): string[] {
+    return this.members.flatMap(({ type }) => type.typeAliasNames());
+  }
+
+  typeAliasDeclarations(): string[] {
+    return this.members.flatMap(({ type }) => type.typeAliasDeclarations());
+  }
+
+  isSettableAsElementAttribute(): boolean {
+    return false;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "declaration": true,
     "experimentalDecorators": true,
-    "lib": ["dom", "es2017", "esnext.array"],
+    "lib": ["es2017", "esnext.array"],
     "moduleResolution": "node",
     "module": "esnext",
     "target": "es2017",
@@ -15,7 +15,8 @@
     "noUnusedParameters": false,
     "outDir": "dist",
     "jsx": "preserve",
-    "sourceMap": true
+    "sourceMap": true,
+    "skipLibCheck": true,
   },
   "include": ["src"],
   "exclude": ["node_modules", "src/resources"]


### PR DESCRIPTION
A Stencil component prop like:

```typescript
 @Prop() oneObjectOrAnother?: ObjectA | ObjectB;
```

…where the members of the union are defined separately:

```typescript
export type ObjectA = {
  someField: string
  anotherField: string
}

export type ObjectB = {
  someOtherField: number
}
```

will now generate an entry in the Elm component's `props` record:

```elm
view :
    { oneObjectOrAnother : Maybe OneObjectOrAnother
   ⋮
```

When passed into the `view` function, this value will be encoded to JSON and set as a property on the DOM node:

```elm
view props =
    node "stencil-button"
        ([ props.oneObjectOrAnother |> Maybe.map (oneObjectOrAnotherEncoder >> property "oneObjectOrAnother")
        ⋮
```

A custom type is generated, along with type aliases for each of the members of the union type:

```elm
type OneObjectOrAnother
    = OneObjectOrAnother0 OneObjectOrAnother0Value
    | OneObjectOrAnother1 OneObjectOrAnother1Value


type alias OneObjectOrAnother0Value =
    { someField : String
    , anotherField : String
    }


type alias OneObjectOrAnother1Value =
    { someOtherField : Int
    }
```

Note that the names are a bit generic, here, as they are all based on the name of the prop only. A possible improvement for the future would be to parse not just the resolved type string but also the original type string (i.e. `ObjectA | ObjectB`) and use that to generate better names for the constructors and type aliases.

Finally, the necessary JSON encoders are also generated:

```elm
oneObjectOrAnotherEncoder : OneObjectOrAnother -> Value
oneObjectOrAnotherEncoder oneObjectOrAnother =
    case oneObjectOrAnother of
        OneObjectOrAnother0 value ->
            oneObjectOrAnother0ValueEncoder value

        OneObjectOrAnother1 value ->
            oneObjectOrAnother1ValueEncoder value


oneObjectOrAnother0ValueEncoder : OneObjectOrAnother0Value -> Value
oneObjectOrAnother0ValueEncoder oneObjectOrAnother0Value =
    Encode.object
        [ ( "someField", Encode.string oneObjectOrAnother0Value.someField )
        , ( "anotherField", Encode.string oneObjectOrAnother0Value.anotherField )
        ]


oneObjectOrAnother1ValueEncoder : OneObjectOrAnother1Value -> Value
oneObjectOrAnother1ValueEncoder oneObjectOrAnother1Value =
    Encode.object
        [ ( "someOtherField", Encode.int oneObjectOrAnother1Value.someOtherField )
        ]
```

Closes #6.