### PR TITLE
Export Props type alias for each component

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "elm-component-lib/"
   ],
   "scripts": {
-    "build": "tsc && npm run rollup",
+    "build": "tsc -p tsconfig.build.json && npm run rollup",
+    "clean": "rm -Rf dist",
     "rollup": "rollup -c",
     "test": "jest"
   },

--- a/src/__tests__/output-elm.spec.ts
+++ b/src/__tests__/output-elm.spec.ts
@@ -1,0 +1,212 @@
+import {
+  ComponentCompilerMeta,
+  ComponentCompilerPropertyType,
+  Encapsulation,
+} from '@stencil/core/internal/stencil-private';
+import { generateProxyElmModule } from '../output-elm';
+
+describe('generateProxyElmModule', () => {
+  it('should generate an Elm module', () => {
+    const cmpMeta = { ...baseCmpMeta, tagName: 'my-foo' };
+
+    const { moduleSrc } = generateProxyElmModule(config, outputTarget, cmpMeta);
+    expect(moduleSrc).toMatch(/^module Components.MyFoo exposing$/m);
+  });
+
+  it('should import necessary Elm modules', () => {
+    const cmpMeta = { ...baseCmpMeta };
+
+    const { moduleSrc } = generateProxyElmModule(config, outputTarget, cmpMeta);
+    expect(moduleSrc).toContain(
+      `
+import Html exposing (Html, node)
+import Html.Attributes exposing (attribute, property)
+import Html.Events exposing (on)
+import Json.Decode as Decode
+import Json.Encode as Encode exposing (Value)
+      `.trim(),
+    );
+  });
+
+  it('should generate a view function', () => {
+    const cmpMeta = { ...baseCmpMeta, tagName: 'my-foo' };
+
+    const { moduleSrc } = generateProxyElmModule(config, outputTarget, cmpMeta);
+    expect(moduleSrc).toContain(
+      `
+view :
+    Maybe String
+    -> Html msg
+view slot =
+    node "my-foo"
+        ([ slot |> Maybe.map (attribute "slot")
+         ]
+            |> List.filterMap identity
+        )
+        []
+      `.trim(),
+    );
+  });
+
+  describe('with an HTML attribute-compatible prop', () => {
+    let cmpMeta: ComponentCompilerMeta;
+
+    beforeEach(() => {
+      cmpMeta = {
+        ...baseCmpMeta,
+        tagName: 'my-foo',
+        properties: [
+          {
+            ...basePropMeta,
+            name: 'myProp',
+            attribute: 'my-prop',
+            type: 'string' as ComponentCompilerPropertyType,
+            complexType: {
+              original: 'string',
+              resolved: 'string',
+              references: {},
+            },
+          },
+        ],
+      };
+    });
+
+    it('should generate a view function that takes a Props argument', () => {
+      const { moduleSrc } = generateProxyElmModule(
+        config,
+        outputTarget,
+        cmpMeta,
+      );
+      expect(moduleSrc).toContain(
+        `
+view :
+    Props
+    -> Html msg
+        `.trim(),
+      );
+    });
+
+    it('should export the Props type alias', () => {
+      const { moduleSrc } = generateProxyElmModule(
+        config,
+        outputTarget,
+        cmpMeta,
+      );
+
+      expect(moduleSrc).toContain(
+        `
+exposing
+    ( view
+    , Props
+    )
+      `.trim(),
+      );
+      expect(moduleSrc).toContain(
+        `
+type alias Props =
+    { myProp : Maybe String
+    , slot : Maybe String
+    }
+        `.trim(),
+      );
+    });
+  });
+
+  const config = {};
+  const outputTarget = { proxiesModuleDir: './Components' };
+  const baseCmpMeta = {
+    assetsDirs: [],
+    componentClassName: '',
+    elementRef: '',
+    encapsulation: 'none' as Encapsulation,
+    shadowDelegatesFocus: false,
+    excludeFromCollection: false,
+    isCollectionDependency: false,
+    isLegacy: false,
+    docs: { text: '', tags: [] },
+    jsFilePath: '',
+    listeners: [],
+    events: [],
+    methods: [],
+    virtualProperties: [],
+    properties: [],
+    watchers: [],
+    sourceFilePath: '',
+    states: [],
+    styleDocs: [],
+    styles: [],
+    tagName: '',
+    internal: false,
+    legacyConnect: [],
+    legacyContext: [],
+
+    // ComponentCompilerFeatures
+    hasAttribute: false,
+    hasAttributeChangedCallbackFn: false,
+    hasComponentWillLoadFn: false,
+    hasComponentDidLoadFn: false,
+    hasComponentShouldUpdateFn: false,
+    hasComponentWillUpdateFn: false,
+    hasComponentDidUpdateFn: false,
+    hasComponentWillRenderFn: false,
+    hasComponentDidRenderFn: false,
+    hasComponentDidUnloadFn: false,
+    hasConnectedCallbackFn: false,
+    hasDisconnectedCallbackFn: false,
+    hasElement: false,
+    hasEvent: false,
+    hasLifecycle: false,
+    hasListener: false,
+    hasListenerTarget: false,
+    hasListenerTargetWindow: false,
+    hasListenerTargetDocument: false,
+    hasListenerTargetBody: false,
+    hasListenerTargetParent: false,
+    hasMember: false,
+    hasMethod: false,
+    hasMode: false,
+    hasProp: false,
+    hasPropBoolean: false,
+    hasPropNumber: false,
+    hasPropString: false,
+    hasPropMutable: false,
+    hasReflect: false,
+    hasRenderFn: false,
+    hasState: false,
+    hasStyle: false,
+    hasVdomAttribute: false,
+    hasVdomClass: false,
+    hasVdomFunctional: false,
+    hasVdomKey: false,
+    hasVdomListener: false,
+    hasVdomPropOrAttr: false,
+    hasVdomRef: false,
+    hasVdomRender: false,
+    hasVdomStyle: false,
+    hasVdomText: false,
+    hasVdomXlink: false,
+    hasWatchCallback: false,
+    htmlAttrNames: [],
+    htmlTagNames: [],
+    isUpdateable: false,
+    isPlain: false,
+    potentialCmpRefs: [],
+  };
+
+  const basePropMeta = {
+    name: '',
+    internal: false,
+
+    // ComponentCompilerStaticProperty
+    mutable: false,
+    optional: false,
+    required: false,
+    type: 'any' as ComponentCompilerPropertyType,
+    complexType: {
+      original: '',
+      resolved: '',
+      references: {},
+    },
+    docs: { text: '', tags: [] },
+  };
+});

--- a/src/event.ts
+++ b/src/event.ts
@@ -24,6 +24,7 @@ export class Event {
   // TODO support decoding CustomEvent detail values
   tagName: string;
   name: string;
+  type: 'event' = 'event';
 
   constructor(cmpMeta: ComponentCompilerMeta, event: ComponentCompilerEvent) {
     this.tagName = cmpMeta.tagName;

--- a/src/output-elm.ts
+++ b/src/output-elm.ts
@@ -209,7 +209,10 @@ function slotProperty(): ComponentCompilerProperty {
 function propTypeAlias(attributeConfigs: (Prop | Event)[]): string | undefined {
   if (attributeConfigs.length > 1)
     return [
-      'type alias Props =',
+      `type alias Props ${
+        // events require a msg type variable
+        attributeConfigs.some((item) => item.type === 'event') ? 'msg ' : ''
+      }=`,
       '    { ' +
         attributeConfigs
           .map((item) => item.fieldTypeAnnotation())

--- a/src/output-elm.ts
+++ b/src/output-elm.ts
@@ -47,15 +47,17 @@ async function generateProxyElmModules(
   outputTarget: OutputTargetElm,
 ) {
   return Promise.all(
-    components.map(
-      generateProxyElmModule.bind(this, compilerCtx, config, outputTarget),
-    ),
+    components
+      .map(generateProxyElmModule.bind(this, config, outputTarget))
+      .map(({ filePath, moduleSrc }) =>
+        compilerCtx.fs.writeFile(filePath, moduleSrc),
+      ),
   );
 }
 
-async function generateProxyElmModule(
+// exported for testing
+export function generateProxyElmModule(
   this: void,
-  compilerCtx: CompilerCtx,
   config: Config,
   outputTarget: OutputTargetElm,
   cmpMeta: ComponentCompilerMeta,
@@ -90,7 +92,7 @@ import Json.Encode as Encode exposing (Value)\n\n\n`;
     generatedCode,
   ].join('\n');
 
-  return compilerCtx.fs.writeFile(filePath, moduleSrc);
+  return { filePath, moduleSrc };
 }
 
 function componentExposures(
@@ -102,13 +104,14 @@ function componentExposures(
 
   return [
     'view',
+    (attributeConfigs.length > 1 && 'Props') || '',
     ...attributeConfigs
       .flatMap((attributeConfig) => attributeConfig.customTypeNames())
       .map((attributeConfig) => `${attributeConfig}(..)`),
     ...attributeConfigs.flatMap((attributeConfig) =>
       attributeConfig.typeAliasNames(),
     ),
-  ];
+  ].filter((str) => str.length > 0);
 }
 
 function componentElm(
@@ -122,12 +125,7 @@ function componentElm(
   const elementFunctionType: string = [
     (attributeConfigs.length === 1 &&
       attributeConfigs[0].argTypeAnnotation()) ||
-      (attributeConfigs.length > 1 &&
-        '{ ' +
-          attributeConfigs
-            .map((item) => item.fieldTypeAnnotation())
-            .join('\n    , ') +
-          '\n    }'),
+      (attributeConfigs.length > 1 && 'Props'),
     takesChildren && 'List (Html msg)',
     'Html msg',
   ]
@@ -154,6 +152,7 @@ function componentElm(
   const children = takesChildren ? 'children' : '[]';
 
   return [
+    propTypeAlias(attributeConfigs) || '',
     [
       `view :`,
       `    ${elementFunctionType}`,
@@ -205,4 +204,16 @@ function slotProperty(): ComponentCompilerProperty {
       references: {},
     },
   };
+}
+
+function propTypeAlias(attributeConfigs: (Prop | Event)[]): string | undefined {
+  if (attributeConfigs.length > 1)
+    return [
+      'type alias Props =',
+      '    { ' +
+        attributeConfigs
+          .map((item) => item.fieldTypeAnnotation())
+          .join('\n    , ') +
+        '\n    }',
+    ].join('\n');
 }

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -8,6 +8,7 @@ import { forComponentProperty, Type } from './prop-types';
 export class Prop {
   propMeta: ComponentCompilerProperty;
   propType: Type;
+  type: 'prop' = 'prop';
 
   constructor(
     config: { logger?: Logger },

--- a/test/jest.preprocessor.js
+++ b/test/jest.preprocessor.js
@@ -1,9 +1,6 @@
 const tsc = require('typescript');
 const tsConfig = require('../tsconfig.json');
 
-// force the output to use commonjs modules required by jest
-tsConfig.compilerOptions.module = 'commonjs';
-
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts') || path.endsWith('.tsx')) {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+  },
+  "exclude": [
+    "node_modules",
+    "src/resources",
+    "**/__tests__/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "experimentalDecorators": true,
     "lib": ["es2017", "esnext.array"],
     "moduleResolution": "node",
-    "module": "esnext",
+    "module": "commonjs",
     "target": "es2017",
     "noUnusedLocals": true,
     "noUnusedParameters": false,
@@ -18,6 +18,11 @@
     "sourceMap": true,
     "skipLibCheck": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "src/resources"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/resources"
+  ]
 }


### PR DESCRIPTION
Users reported having to alias or write out the full type definition in consuming code, which was painful.

Before:

```elm
module Components.MyComponent exposing
    ( view
    )


view :
    { propA: String
    , propB: Maybe Bool
    , slot: Maybe String
    }
    -> Html msg
view props =
    …
```

After:
```elm
module Components.MyComponent exposing
    ( view
    , Props
    )


type alias Props =
    { propA: String
    , propB: Maybe Bool
    , slot: Maybe String
    }


view :
    Props
    -> Html msg
view props =
    …
```

This also introduces an initial integration test for the plugin, to cover this new functionality.